### PR TITLE
Expose socket

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,12 @@ exports.createServer = function (onConnection) {
 
     wsServer.on('connection', function (socket) {
       var stream = ws(socket)
-      stream.socket = socket
+      stream.address=addr
+      stream.remoteAddress={
+        host:socket.upgradeReq.connection.remoteAddress,
+        port:socket.upgradeReq.connection.remotePort
+      }
+      stream.headers = socket.upgradeReq.headers
       emitter.emit('connection', stream)
     })
 


### PR DESCRIPTION
Currently is the socket exposed in the client.connect method, but not by the server on('connection') event, so I can not access to the socket.upgradeReq object.
I need access e.g to the remote address for logging purposes.
