### PR TITLE
add verifyClient option to the server creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,21 @@ var tlsOpts = {
   key: fs.readFileSync('test/fixtures/keys/agent2-key.pem'),
   cert: fs.readFileSync('test/fixtures/keys/agent2-cert.pem')
 };
-ws.createServer(tlsOpts, function (stream) {
+ws.createServer({ tls: tlsOpts }, function (stream) {
   //pipe duplex style to your service.
   pull(stream, service.createStream(), stream)
 })
 .listen(9999)
+```
+
+To add client-authentication to the server, you can set `verifyClient`.
+[Documentation here](https://github.com/websockets/ws/blob/master/doc/ws.md#optionsverifyclient).
+
+```js
+function verifyClient (info) {
+  return info.secure == true
+}
+ws.createServer({ verifyClient: verifyClient }, onStream)
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -8,13 +8,14 @@ exports.connect = require('./client').connect
 
 var EventEmitter = require('events').EventEmitter
 
-exports.createServer = function (tlsOpts, onConnection) {
+exports.createServer = function (opts, onConnection) {
   var emitter = new EventEmitter()
   var server
-  if (typeof tlsOpts === 'function'){
-    onConnection = tlsOpts
-    tlsOpts = null
+  if (typeof opts === 'function'){
+    onConnection = opts
+    opts = null
   }
+  opts = opts || {}
 
   if(onConnection)
     emitter.on('connection', onConnection)
@@ -26,8 +27,11 @@ exports.createServer = function (tlsOpts, onConnection) {
       emitter.emit.apply(emitter, args)
     })
   }
-  var server = (tlsOpts) ? https.createServer(tlsOpts) : http.createServer()
-  var wsServer = new WebSocket.Server({server: server})
+  var server = (opts.tls) ? https.createServer(opts.tls) : http.createServer()
+  var wsServer = new WebSocket.Server({
+    server: server,
+    verifyClient: opts.verifyClient
+  })
 
   emitter.listen = function (addr, onListening) {
     proxy(server, 'listening')


### PR DESCRIPTION
This change makes it possible to run authentication on a client before accepting the connection. This is necessary to enforce CORS.

Docs for verifyClient here: https://github.com/websockets/ws/blob/master/doc/ws.md#optionsverifyclient

This is a major-breaking change, due to how I updated the function signature.