### PR TITLE
support use with an external server

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ function verifyClient (info) {
 ws.createServer({ verifyClient: verifyClient }, onStream)
 ```
 
+## use with an http server
+
+if you have an http server that you also need to serve stuff
+over, and want to use a single port, use the `server` option.
+
+``` js
+var http = require('http')
+var server = http.createServer(function(req, res){...}).listen(....)
+ws.createServer({server: server}, function (stream) { ... })
+
+```
+
 ## License
 
 MIT

--- a/test/server.js
+++ b/test/server.js
@@ -1,0 +1,50 @@
+
+var WS = require('../')
+var tape = require('tape')
+var pull = require('pull-stream')
+var JSONDL = require('pull-json-doubleline')
+
+tape('simple echo server', function (t) {
+  var http_server = require('http').createServer()
+
+  var server = WS.createServer({server: http_server}, function (stream) {
+    pull(stream, pull.through(console.log), stream)
+  })
+
+  server.listen(5678, function () {
+    WS.connect('ws://localhost:5678', function (err, stream) {
+      pull(
+        pull.values([1,2,3]),
+        //need a delay, because otherwise ws hangs up wrong.
+        //otherwise use pull-goodbye.
+        function (read) {
+          return function (err, cb) {
+            setTimeout(function () {
+              read(null, cb)
+            }, 10)
+          }
+        },
+        JSONDL.stringify(),
+        stream,
+        JSONDL.parse(),
+        pull.collect(function (err, ary) {
+          if(err) throw err
+          t.deepEqual(ary, [1,2,3])
+          server.close(function () {
+            t.end()
+          })
+        })
+      )
+    })
+  })
+
+
+
+})
+
+
+
+
+
+
+


### PR DESCRIPTION
this allows you to use websockets on the same port as your http server.
similar to the way that other websocket libraries work.